### PR TITLE
Enforce dev-only merges to main with GitHub Action

### DIFF
--- a/.github/workflows/check-pull-request-branch.yml
+++ b/.github/workflows/check-pull-request-branch.yml
@@ -1,0 +1,20 @@
+name: Check pull request source branch
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+jobs:
+  check-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branches
+        run: |
+          if [ ${{ github.head_ref }} != "dev" ] && [ ${{ github.base_ref }} == "main" ]; then
+            echo "Merge requests to main branch are only allowed from dev branch."
+            exit 1
+          fi


### PR DESCRIPTION
Adds a workflow to ensure only the dev branch can merge into main by failing PRs from other branches, enhancing branch protection.